### PR TITLE
Replace netcat with netcat-openbsc

### DIFF
--- a/Dockerfile.tpl
+++ b/Dockerfile.tpl
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
       libjpeg-dev \
       ssh \
       rsync \
-      netcat \
+      netcat-openbsd \
     && rm -r /var/lib/apt/lists/* \
     && docker-php-ext-configure \
 {{- if or (or (matchVersion "^7.4" .Tag) (matchVersion "^8" .Tag)) (eq "7" .Version)  }}

--- a/base-chaser.lock
+++ b/base-chaser.lock
@@ -27,18 +27,6 @@ images:
       os: linux
       architecture: amd64
       last_updated_at: 2023-12-20T09:02:25.336696Z
-    - pattern: ^8.3.[0-9]+\-cli\-bookworm$
-      version: ^8.3.0
-      resolved: 8.3.0-cli-bookworm
-      os: linux
-      architecture: amd64
-      last_updated_at: 2023-12-20T09:08:33.903348Z
-    - pattern: ^8.3\-cli\-bookworm$
-      version: ^8.3
-      resolved: 8.3-cli-bookworm
-      os: linux
-      architecture: amd64
-      last_updated_at: 2023-12-20T09:02:20.26592Z
     - pattern: ^8.3.[0-9]+\-apache\-bullseye$
       version: ^8.3.0
       resolved: 8.3.0-apache-bullseye
@@ -51,18 +39,6 @@ images:
       os: linux
       architecture: amd64
       last_updated_at: 2023-12-20T09:01:51.760491Z
-    - pattern: ^8.3.[0-9]+\-apache\-bookworm$
-      version: ^8.3.0
-      resolved: 8.3.0-apache-bookworm
-      os: linux
-      architecture: amd64
-      last_updated_at: 2023-12-20T09:07:58.543893Z
-    - pattern: ^8.3\-apache\-bookworm$
-      version: ^8.3
-      resolved: 8.3-apache-bookworm
-      os: linux
-      architecture: amd64
-      last_updated_at: 2023-12-20T09:01:45.447267Z
     - pattern: ^8.3.[0-9]+\-fpm\-bullseye$
       version: ^8.3.0
       resolved: 8.3.0-fpm-bullseye
@@ -75,18 +51,6 @@ images:
       os: linux
       architecture: amd64
       last_updated_at: 2023-12-20T09:02:48.450446Z
-    - pattern: ^8.3.[0-9]+\-fpm\-bookworm$
-      version: ^8.3.0
-      resolved: 8.3.0-fpm-bookworm
-      os: linux
-      architecture: amd64
-      last_updated_at: 2023-12-20T09:08:59.578206Z
-    - pattern: ^8.3\-fpm\-bookworm$
-      version: ^8.3
-      resolved: 8.3-fpm-bookworm
-      os: linux
-      architecture: amd64
-      last_updated_at: 2023-12-20T09:02:42.353289Z
     - pattern: ^8.2.[0-9]+\-cli\-bullseye$
       version: ^8.2.0
       resolved: 8.2.13-cli-bullseye


### PR DESCRIPTION
Error during build with bookworm due to missing netcat package.

```
root@1367dd013ce9:/var/www/html# apt-get -y install netcat
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package netcat is a virtual package provided by:
  netcat-openbsd 1.219-1
  netcat-traditional 1.10-47
You should explicitly select one to install.

E: Package 'netcat' has no installation candidate
```

https://packages.debian.org/ja/bookworm/netcat

I explicitly stated to use netcat-openbsd.